### PR TITLE
Replace post-switch function with a hook

### DIFF
--- a/theme-looper-tests.el
+++ b/theme-looper-tests.el
@@ -130,9 +130,9 @@
           ;;Should apply customizations when specified
           (load-theme 'tango
                       t)
-	      (theme-looper-set-post-switch-script (lambda ()
-                                                 (set-face-background 'default
-                                                                      "green")))
+	      (add-hook 'theme-looper-post-switch-hook
+                    (lambda ()
+                      (set-face-background 'default "green")))
 	      (theme-looper-enable-next-theme)
 	      (message (concat "found face-background: "
                            (face-background 'default)))

--- a/theme-looper-tests.el
+++ b/theme-looper-tests.el
@@ -51,8 +51,8 @@
 	      (theme-looper--disable-all-themes)
 	      (should (equal custom-enabled-themes
 			             '())))
-      (load-theme current-theme
-                  t))))
+      (when current-theme
+        (load-theme current-theme t)))))
 
 (ert-deftest tl-test:getting-theme-indices ()
   (let ((current-theme (car custom-enabled-themes)))
@@ -86,8 +86,8 @@
 			             'wombat)))
       (setq theme-looper--favorite-themes
 	        (custom-available-themes))
-      (load-theme current-theme
-                  t))))
+      (when current-theme
+        (load-theme current-theme t)))))
 
 (ert-deftest tl-test:setting-next-theme ()
   (let ((current-theme (car custom-enabled-themes)))
@@ -113,8 +113,9 @@
 			             '(wombat))))
       (setq theme-looper--favorite-themes
 	        (custom-available-themes))
-      (load-theme current-theme
-                  t))))
+      (when current-theme
+        (load-theme current-theme
+                    t)))))
 
 (ert-deftest tl-test:adding-customization ()
   (let ((current-theme (car custom-enabled-themes))
@@ -122,9 +123,8 @@
 					                         :height)))
     (unwind-protect
 	    (progn
-          (message (concatenate 'string
-                                "current-face-height: "
-                                (number-to-string current-face-height)))
+          (message (concat "current-face-height: "
+                           (number-to-string current-face-height)))
 	      (theme-looper-set-favorite-themes (list 'wombat
                                                   'tango-dark
                                                   'wheatgrass))
@@ -135,16 +135,15 @@
                                                  (set-face-attribute 'default nil
                                                                      :height 120)))
 	      (theme-looper-enable-next-theme)
-	      (message (concatenate 'string
-                                "found face-height: "
-                                (number-to-string (face-attribute 'default :height))))
+	      (message (concat "found face-height: "
+                           (number-to-string (face-attribute 'default :height))))
 	      (should (< (abs  (- (face-attribute 'default :height)
 			                  120))
 		             2)))
       (setq theme-looper--favorite-themes
 	        (custom-available-themes))
-      (load-theme current-theme
-                  t)
+      (when current-theme
+        (load-theme current-theme t))
       (set-face-attribute 'default nil
 			              :height current-face-height))))
 

--- a/theme-looper-tests.el
+++ b/theme-looper-tests.el
@@ -119,32 +119,29 @@
 
 (ert-deftest tl-test:adding-customization ()
   (let ((current-theme (car custom-enabled-themes))
-	    (current-face-height (face-attribute 'default
-					                         :height)))
+	    (current-face-background (face-background 'default)))
     (unwind-protect
 	    (progn
-          (message (concat "current-face-height: "
-                           (number-to-string current-face-height)))
-	      (theme-looper-set-favorite-themes (list 'wombat
+          (set-face-background 'default "red")
+          (message (concat "current face-background: red"))
+          (theme-looper-set-favorite-themes (list 'wombat
                                                   'tango-dark
                                                   'wheatgrass))
           ;;Should apply customizations when specified
-	      (load-theme 'tango
+          (load-theme 'tango
                       t)
 	      (theme-looper-set-post-switch-script (lambda ()
-                                                 (set-face-attribute 'default nil
-                                                                     :height 120)))
+                                                 (set-face-background 'default
+                                                                      "green")))
 	      (theme-looper-enable-next-theme)
-	      (message (concat "found face-height: "
-                           (number-to-string (face-attribute 'default :height))))
-	      (should (< (abs  (- (face-attribute 'default :height)
-			                  120))
-		             2)))
+	      (message (concat "found face-background: "
+                           (face-background 'default)))
+	      (should (equal (face-background 'default) "green")))
       (setq theme-looper--favorite-themes
 	        (custom-available-themes))
+      (setq theme-looper-post-switch-hook nil)
       (when current-theme
         (load-theme current-theme t))
-      (set-face-attribute 'default nil
-			              :height current-face-height))))
+      (set-face-background 'default current-face-background))))
 
 ;;; theme-looper-tests.el ends here

--- a/theme-looper.el
+++ b/theme-looper.el
@@ -69,9 +69,9 @@
 ;;
 ;;     (theme-looper-reset-themes-selection)
 ;;
-;; You can set some script to be run after every theme switch
+;; You can set hook functions to be run after every theme switch
 ;;
-;;     (theme-looper-set-post-switch-script my-func)
+;;     (add-hook 'theme-looper-post-switch-hook 'my-func)
 ;;
 
 ;;; Commentary:
@@ -95,8 +95,8 @@
 (defvar theme-looper--ignored-themes
   nil)
 
-(defun theme-looper--post-switch
-    nil)
+(defvar theme-looper-post-switch-hook nil
+  "Hook that runs after selecting a theme.")
 
 (defvar theme-looper--themes-map-separator
   " | ")
@@ -133,12 +133,6 @@
                             (string-match-p regexp
                                             (symbol-name theme)))
                           (custom-available-themes))))
-
-;;;###autoload
-(defun theme-looper-set-post-switch-script (func)
-  "Sets script to be run after every theme switch"
-  (setq theme-looper--post-switch
-        func))
 
 ;;;###autoload
 (defun theme-looper-reset-themes-selection ()
@@ -253,7 +247,7 @@
   (theme-looper--disable-all-themes)
   (load-theme theme
               t)
-  (theme-looper--post-switch))
+  (run-hooks 'theme-looper-post-switch-hook))
 
 ;;;###autoload
 (defun theme-looper-enable-next-theme ()

--- a/theme-looper.el
+++ b/theme-looper.el
@@ -77,7 +77,7 @@
 ;;; Commentary:
 
 ;;     You can use this package to cycle through color themes in Emacs with a
-;;     shortcut. Select your favorite themes, unfavorite thmes and key-bindings
+;;     shortcut. Select your favorite themes, unfavorite themes and key-bindings
 ;;     to switch color themes in style!
 ;;
 ;;  Overview of features:


### PR DESCRIPTION
Thank you for this package, it's been very useful so far!

This PR is the first of two I would like to submit. The combined from both is on my fork at [ff-merge](https://github.com/fishyfriend/theme-looper/tree/ff-merge) branch if you prefer to look there. 

This PR fixes a couple issues with the post-switch functionality and tests, and adds the ability to support multiple post-switch functions.

The main issue is that user's post-switch function is not called as intended. `theme-looper-set-post-switch-script` uses `setq` which can't modify function values, only variables, so user's definition is stored in a variable called `theme-looper--post-switch` rather than the identically-named function.

To fix this issue I replaced the switch function with a hook variable which can be modified directly by the user using `add-hook`. I believe this is more consistent with the way other Emacs features expose pre-/post-action triggers. As a bonus, it also makes it simple to add multiple post-switch functions instead of just one.

Additionally I made a few changes to the tests:
* Even after fixing the post-switch function, the test for it was not working. The test relies on customizing a font size, but it appears different Emacs may have different rules for translating requested to actual font sizes. (My Emacs setup does, anyway.) I replaced the font size with background color instead, which should hopefully be more consistent.
* Replaced `concatenate` with `concat` for compatibility with newer Emacs. `concat` appears to be available in Emacs 24+, so seems safe to do this.
* Fixed test failure when the user did not already have a custom theme selected before running the tests.

Cheers,
Jacob