### PR TITLE
allow selecting special *default* theme to restore Emacs defaults

### DIFF
--- a/theme-looper-tests.el
+++ b/theme-looper-tests.el
@@ -148,4 +148,15 @@
       (set-face-attribute 'default nil
 			              :height current-face-height))))
 
+(ert-deftest tl-test:emacs-defaults ()
+  (let ((current-theme (car custom-enabled-themes)))
+    (unwind-protect
+        (progn
+          (theme-looper-enable-theme '*default*)
+          (should (not custom-enabled-themes))
+          (should (eq (theme-looper--get-current-theme)
+                      '*default*)))
+      (when current-theme
+        (load-theme current-theme t)))))
+
 ;;; theme-looper-tests.el ends here


### PR DESCRIPTION
This PR adds a special symbol `*default*` that can be used to select Emacs default settings (no theme). It was already possible to use `nil` for this but I wanted something more explicit and that would play nice with the regexp functionality.

Combined code from this and #9 are available on my fork's [ff-merge](https://github.com/fishyfriend/theme-looper/tree/ff-merge) branch if you prefer to have a look there.

Cheers,
Jacob