### PR TITLE
Fixed 'nth-cyclic' is not known to be defined.

### DIFF
--- a/theme-looper.el
+++ b/theme-looper.el
@@ -187,7 +187,7 @@ Pass `*default*' to select Emacs defaults."
 
 (defun theme-looper--enable-theme-with-map (theme)
   "Enables a theme with displayed map."
-  (cl-flet* ((nth-cyclic (index collection)
+  (cl-labels ((nth-cyclic (index collection)
                          (cond ((< index
                                    0) (nth-cyclic (+ index
                                                      (length collection))


### PR DESCRIPTION
`cl-flet*` doesn't allow recursive function calls in the bound functions. Replaced `cl-flet*` with `cl-labels` so the current `theme-looper--enable-theme-with-map` works as written. This fixes issue #16.